### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -33,7 +33,7 @@ def health_check():
         current_app.logger.error(f"Health check failed: {e}")
         return jsonify({
             'status': 'unhealthy',
-            'error': str(e),
+            'error': 'Health check failed',
             'timestamp': datetime.now().isoformat()
         }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Subscription-Tracker/security/code-scanning/2](https://github.com/GitTimeraider/Subscription-Tracker/security/code-scanning/2)

To fix the problem, we should avoid exposing the exception message (`str(e)`) to the client in the JSON response. Instead, we should return a generic error message (e.g., "An internal error has occurred" or "Health check failed") in the `error` field. The detailed exception information should be logged on the server using `current_app.logger.error`, as is already being done. This change should be made only in the exception handler of the `/health` route in `app/routes.py`, specifically on line 36. No new imports are needed, as logging is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
