### PR TITLE
Currency exchange refresh fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ DATABASE_URL=mysql+pymysql://username:password@mariadb:3306/database_name
 #### Currency Exchange Variables
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CURRENCY_REFRESH_MINUTES` | Freshness window for cached exchange rates (per provider) | 1440 (24h) |
+| `CURRENCY_REFRESH_MINUTES` | Freshness window for cached exchange rates and the background auto-refresh interval (per provider) | 1440 (24h) |
 | `CURRENCY_PROVIDER_PRIORITY` | Comma list controlling provider fallback order | frankfurter,floatrates,erapi_open |
 
 
@@ -230,6 +230,8 @@ Currently bundled free, no‑key providers (all EUR base):
 You can set a personal preference in General Settings. The system builds a dynamic priority list putting your choice first, followed by the remaining providers, then falls back to: any cached provider for today → most recent historical cached record → static hardcoded approximations (last resort). A mismatch warning appears if your preferred provider is temporarily unavailable.
 
 Manual Refresh: In General Settings click the “Refresh Rates” button (POST `/refresh_rates`) to clear today’s cache and force a live refetch. A debug JSON endpoint is also available at `/debug/refresh_rates` (authenticated) to inspect raw values and sample conversions.
+
+Automatic Refresh: The app starts a background currency refresh job alongside the existing notification scheduler. By default it refreshes cached rates every `CURRENCY_REFRESH_MINUTES` minutes so the dashboard keeps updated values even when nobody opens the settings page.
 
 Precision: All conversions use Python `Decimal` with high precision to avoid cumulative rounding issues when summing many subscriptions.
 

--- a/app/currency.py
+++ b/app/currency.py
@@ -1,10 +1,12 @@
 import requests
 import json
 import os
+import atexit
 from datetime import datetime, date, timezone
 from flask import current_app
 import xml.etree.ElementTree as ET
 from decimal import Decimal, getcontext, InvalidOperation
+from apscheduler.schedulers.background import BackgroundScheduler
 
 # High precision for chained conversions
 getcontext().prec = 28
@@ -354,3 +356,34 @@ class CurrencyConverter:
 
 # Global converter instance
 currency_converter = CurrencyConverter()
+
+
+def refresh_exchange_rates(app, base_currency='EUR'):
+    """Force a live refresh so background jobs keep cached rates warm."""
+    with app.app_context():
+        return currency_converter.get_exchange_rates(base_currency, force_refresh=True)
+
+
+def start_currency_refresh_scheduler(app):
+    """Start a background job that periodically refreshes cached exchange rates."""
+    if getattr(app, '_currency_refresh_scheduler', None):
+        return
+
+    refresh_minutes = int(os.getenv('CURRENCY_REFRESH_MINUTES', '1440'))
+    if refresh_minutes <= 0:
+        app.logger.info('Currency auto-refresh disabled (CURRENCY_REFRESH_MINUTES <= 0)')
+        return
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        func=lambda: refresh_exchange_rates(app),
+        trigger='interval',
+        minutes=refresh_minutes,
+        id='refresh_currency_rates',
+        replace_existing=True,
+        max_instances=1,
+    )
+    scheduler.start()
+    app._currency_refresh_scheduler = scheduler
+    atexit.register(lambda: scheduler.shutdown())
+    app.logger.info(f'Currency refresh scheduler started (every {refresh_minutes} minutes)')

--- a/app/email.py
+++ b/app/email.py
@@ -446,6 +446,12 @@ def start_scheduler(app):
     atexit.register(lambda: scheduler.shutdown())
     print("✅ Email notification scheduler started (checking hourly)")
 
+    try:
+        from app.currency import start_currency_refresh_scheduler
+        start_currency_refresh_scheduler(app)
+    except Exception as e:
+        print(f"⚠️  Currency refresh scheduler could not start: {e}")
+
 def send_test_email(app, user):
     """Send a test email to verify email configuration"""
     with app.app_context():

--- a/tests/test_daily_reminders.py
+++ b/tests/test_daily_reminders.py
@@ -371,3 +371,39 @@ class TestTimezoneAwareScheduling:
             settings.timezone = "UTC"
             settings.notification_time = 9
             db.session.commit()
+
+
+def test_notification_scheduler_also_starts_currency_refresh_scheduler():
+    import app.email as email_mod
+
+    class _FakeScheduler:
+        def __init__(self):
+            self.started = False
+
+        def add_job(self, **kwargs):
+            self.job = kwargs
+
+        def start(self):
+            self.started = True
+
+        def shutdown(self):
+            return None
+
+    class _FakeLogger:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    class _FakeApp:
+        def __init__(self):
+            self.logger = _FakeLogger()
+            self._notification_scheduler = None
+
+    fake_app = _FakeApp()
+    fake_scheduler = _FakeScheduler()
+
+    with patch.object(email_mod, "BackgroundScheduler", return_value=fake_scheduler):
+        with patch("app.currency.start_currency_refresh_scheduler") as start_currency_scheduler:
+            email_mod.start_scheduler(fake_app)
+
+    assert fake_scheduler.started is True
+    start_currency_scheduler.assert_called_once_with(fake_app)


### PR DESCRIPTION
Currency exchange refresh fixes
Noticed issues at time where the currency didnt refresh correctly at page load and thus generated an error.
Adjusted it so it self-heals but also checks the currency rates once a day regardless of whether someone opens the webpage or not meaning it should always be up-to-date and after a failure should have enough time to self-heal.